### PR TITLE
StorageSystemFactsModule for HPE OneView

### DIFF
--- a/lib/ansible/modules/remote_management/oneview/oneview_storage_system_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_storage_system_facts.py
@@ -18,12 +18,12 @@ description:
     - Retrieve facts about the Storage Systems from OneView.
 version_added: "2.5"
 requirements:
-    - hpOneView >= 4.0.0
+    - "hpOneView >= 2.0.1"
 author:
-    - Priyanka Sood (@soodpr)
-    - Madhav Bharadwaj (@madhav-bharadwaj)
-    - Ricardo Galeno (@ricardogpsf)
     - Alex Monteiro (@aalexmonteiro)
+    - Madhav Bharadwaj (@madhav-bharadwaj)
+    - Priyanka Sood (@soodpr)
+    - Ricardo Galeno (@ricardogpsf)
 options:
     storage_hostname:
       description:
@@ -33,13 +33,13 @@ options:
         - Storage System name.
     options:
       description:
-        - "List with options to gather additional facts about a Storage System and related resources.
-          Options allowed:
-          C(hostTypes) gets the list of supported host types.
-          C(storagePools) gets a list of storage pools belonging to the specified storage system.
-          C(reachablePorts) gets a list of storage system reachable ports. Accepts C(params).
+        - List with options to gather additional facts about a Storage System and related resources.
+        - "options allowed:
+          - C(hostTypes) gets the list of supported host types.
+          - C(storagePools) gets a list of storage pools belonging to the specified storage system.
+          - C(reachablePorts) gets a list of storage system reachable ports. Accepts C(params).
             An additional C(networks) list param can be used to restrict the search for only these ones.
-          C(templates) gets a list of storage templates belonging to the storage system."
+          - C(templates) gets a list of storage templates belonging to the storage system."
         - "To gather facts about C(storagePools), C(reachablePorts), and C(templates) it is required to inform
             either the argument C(name), or C(storage_hostname). Otherwise, this option will be ignored."
 extends_documentation_fragment:

--- a/lib/ansible/modules/remote_management/oneview/oneview_storage_system_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_storage_system_facts.py
@@ -1,0 +1,255 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2016-2017, Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: oneview_storage_system_facts
+short_description: Retrieve facts about the OneView Storage Systems
+description:
+    - Retrieve facts about the Storage Systems from OneView.
+version_added: "2.5"
+requirements:
+    - hpOneView >= 4.0.0
+author:
+    - Priyanka Sood (@soodpr)
+    - Madhav Bharadwaj (@madhav-bharadwaj)
+    - Ricardo Galeno (@ricardogpsf)
+    - Alex Monteiro (@aalexmonteiro)
+options:
+    storage_hostname:
+      description:
+        - Storage System IP or hostname.
+    name:
+      description:
+        - Storage System name.
+    options:
+      description:
+        - "List with options to gather additional facts about a Storage System and related resources.
+          Options allowed:
+          C(hostTypes) gets the list of supported host types.
+          C(storagePools) gets a list of storage pools belonging to the specified storage system.
+          C(reachablePorts) gets a list of storage system reachable ports. Accepts C(params).
+            An additional C(networks) list param can be used to restrict the search for only these ones.
+          C(templates) gets a list of storage templates belonging to the storage system."
+        - "To gather facts about C(storagePools), C(reachablePorts), and C(templates) it is required to inform
+            either the argument C(name), or C(storage_hostname). Otherwise, this option will be ignored."
+extends_documentation_fragment:
+    - oneview
+    - oneview.factsparams
+'''
+
+EXAMPLES = '''
+- name: Gather facts about all Storage Systems
+  oneview_storage_system_facts:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=storage_systems
+
+- name: Gather paginated, filtered and sorted facts about Storage Systems
+  oneview_storage_system_facts:
+    params:
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: managedDomain=TestDomain
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+  no_log: true
+
+- debug: var=storage_systems
+
+- name: Gather facts about a Storage System by IP
+  oneview_storage_system_facts:
+    storage_hostname: "172.18.11.12"
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=storage_systems
+
+- name: Gather facts about a Storage System by hostname
+  oneview_storage_system_facts:
+    storage_hostname: "172.18.11.12"
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=storage_systems
+
+
+- name: Gather facts about a Storage System by name
+  oneview_storage_system_facts:
+    name: "ThreePAR7200-4555"
+    storage_hostname: "172.18.11.12"
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=storage_systems
+
+- name: Gather facts about a Storage System and all options
+  oneview_storage_system_facts:
+    name: "ThreePAR7200-4555"
+    options:
+        - hostTypes
+        - storagePools
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=storage_systems
+- debug: var=storage_system_host_types
+- debug: var=storage_system_pools
+
+- name: Gather queried facts about Storage System reachable ports
+  oneview_storage_system_facts:
+    storage_hostname: "172.18.11.12"
+    options:
+        - reachablePorts
+    params:
+      networks:
+        - /rest/fc-networks/01FC123456
+        - /rest/fc-networks/02FC123456
+      sort: 'name:descending'
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+  no_log: true
+
+- debug: var=storage_system_reachable_ports
+
+- name: Gather facts about Storage System storage templates
+  oneview_storage_system_facts:
+    storage_hostname: "172.18.11.12"
+    options:
+      - templates
+    params:
+      sort: 'name:descending'
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+  no_log: true
+
+- debug: var=storage_system_templates
+'''
+
+RETURN = '''
+storage_systems:
+    description: Has all the OneView facts about the Storage Systems.
+    returned: Always, but can be null.
+    type: dict
+
+storage_system_host_types:
+    description: Has all the OneView facts about the supported host types.
+    returned: When requested, but can be null.
+    type: dict
+
+storage_system_pools:
+    description: Has all the OneView facts about the Storage Systems - Storage Pools.
+    returned: When requested, but can be null.
+    type: dict
+
+storage_system_reachable_ports:
+    description: Has all the OneView facts about the Storage Systems reachable ports.
+    returned: When requested, but can be null.
+    type: dict
+
+storage_system_templates:
+    description: Has all the OneView facts about the Storage Systems - Storage Templates.
+    returned: When requested, but can be null.
+    type: dict
+'''
+
+from ansible.module_utils.oneview import OneViewModuleBase
+
+
+class StorageSystemFactsModule(OneViewModuleBase):
+    def __init__(self):
+        argument_spec = dict(
+            name=dict(type='str'),
+            options=dict(type='list'),
+            params=dict(type='dict'),
+            storage_hostname=dict(type='str')
+        )
+
+        super(StorageSystemFactsModule, self).__init__(additional_arg_spec=argument_spec)
+        self.resource_client = self.oneview_client.storage_systems
+
+    def execute_module(self):
+        facts = {}
+        is_specific_storage_system = True
+        # This allows using both "ip_hostname" and "hostname" regardless api_version
+        if self.oneview_client.api_version >= 500:
+            get_method = self.oneview_client.storage_systems.get_by_hostname
+        else:
+            get_method = self.oneview_client.storage_systems.get_by_ip_hostname
+
+        if self.module.params.get('storage_hostname'):
+            storage_systems = get_method(self.module.params['storage_hostname'])
+        elif self.module.params.get('name'):
+            storage_systems = self.oneview_client.storage_systems.get_by_name(self.module.params['name'])
+        else:
+            storage_systems = self.oneview_client.storage_systems.get_all(**self.facts_params)
+            is_specific_storage_system = False
+
+        self.__get_options(facts, storage_systems, is_specific_storage_system)
+
+        facts['storage_systems'] = storage_systems
+
+        return dict(changed=False, ansible_facts=facts)
+
+    def __get_options(self, facts, storage_system, is_specific_storage_system):
+
+        if self.options:
+            if self.options.get('hostTypes'):
+                facts['storage_system_host_types'] = self.oneview_client.storage_systems.get_host_types()
+
+            if storage_system and is_specific_storage_system:
+                storage_uri = storage_system['uri']
+                query_params = self.module.params.get('params', {})
+                if self.options.get('storagePools'):
+                    facts['storage_system_pools'] = self.oneview_client.storage_systems.get_storage_pools(storage_uri)
+                if self.options.get('reachablePorts'):
+                    facts['storage_system_reachable_ports'] = \
+                        self.oneview_client.storage_systems.get_reachable_ports(storage_uri, **query_params)
+                if self.options.get('templates'):
+                    facts['storage_system_templates'] = \
+                        self.oneview_client.storage_systems.get_templates(storage_uri, **query_params)
+
+
+def main():
+    StorageSystemFactsModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/remote_management/oneview/test_oneview_storage_system_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_storage_system_facts.py
@@ -2,6 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from ansible.compat.tests import unittest
+from oneview_module_loader import OneViewModuleBase
 from ansible.modules.remote_management.oneview.oneview_storage_system_facts import StorageSystemFactsModule
 from hpe_test_utils import FactsParamsTestCase
 

--- a/test/units/modules/remote_management/oneview/test_oneview_storage_system_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_storage_system_facts.py
@@ -1,0 +1,187 @@
+# Copyright: (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.compat.tests import unittest
+from ansible.modules.remote_management.oneview.oneview_storage_system_facts import StorageSystemFactsModule
+from hpe_test_utils import FactsParamsTestCase
+
+PARAMS_GET_ALL = dict(
+    config='config.json',
+    name=None
+)
+
+PARAMS_GET_BY_NAME = dict(
+    config='config.json',
+    name="Test Storage Systems"
+)
+
+PARAMS_GET_BY_HOSTNAME = dict(
+    config='config.json',
+    storage_hostname='10.0.0.0'
+)
+
+PARAMS_GET_HOST_TYPES = dict(
+    config='config.json',
+    options=["hostTypes"]
+)
+
+PARAMS_GET_REACHABLE_PORTS = dict(
+    config='config.json',
+    storage_hostname='10.0.0.0',
+    options=["reachablePorts"]
+)
+
+PARAMS_GET_TEMPLATES = dict(
+    config='config.json',
+    storage_hostname='10.0.0.0',
+    options=["templates"]
+)
+
+HOST_TYPES = [
+    "Citrix Xen Server 5.x/6.x",
+    "IBM VIO Server",
+]
+
+PARAMS_GET_POOL_BY_NAME = dict(
+    config='config.json',
+    name="Test Storage Systems",
+    options=["storagePools"]
+)
+
+PARAMS_GET_POOL_BY_IP_HOSTNAME = dict(
+    config='config.json',
+    storage_hostname='10.0.0.0',
+    options=["storagePools"]
+)
+
+
+class StorageSystemFactsSpec(unittest.TestCase,
+                             FactsParamsTestCase):
+    def setUp(self):
+        self.configure_mocks(self, StorageSystemFactsModule)
+        self.storage_systems = self.mock_ov_client.storage_systems
+        self.mock_ov_client.api_version = 300
+        FactsParamsTestCase.configure_client_mock(self, self.storage_systems)
+
+    def test_should_get_all_storage_system(self):
+        self.storage_systems.get_all.return_value = {"name": "Storage System Name"}
+        self.mock_ansible_module.params = PARAMS_GET_ALL
+
+        StorageSystemFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(storage_systems=({"name": "Storage System Name"}))
+        )
+
+    def test_should_get_storage_system_by_name(self):
+        self.storage_systems.get_by_name.return_value = {"name": "Storage System Name"}
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
+
+        StorageSystemFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(storage_systems=({"name": "Storage System Name"}))
+        )
+
+    def test_should_get_storage_system_by_ip_hostname(self):
+        self.storage_systems.get_by_ip_hostname.return_value = {"ip_hostname": "10.0.0.0"}
+        self.mock_ansible_module.params = PARAMS_GET_BY_HOSTNAME
+
+        StorageSystemFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(storage_systems=({"ip_hostname": "10.0.0.0"}))
+        )
+
+    def test_should_get_storage_system_by_hostname(self):
+        self.mock_ov_client.api_version = 500
+        self.storage_systems.get_by_hostname.return_value = {"hostname": "10.0.0.0"}
+        self.mock_ansible_module.params = PARAMS_GET_BY_HOSTNAME
+
+        StorageSystemFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(storage_systems=({"hostname": "10.0.0.0"}))
+        )
+
+    def test_should_get_all_host_types(self):
+        self.storage_systems.get_host_types.return_value = HOST_TYPES
+        self.storage_systems.get_all.return_value = [{"name": "Storage System Name"}]
+        self.mock_ansible_module.params = PARAMS_GET_HOST_TYPES
+
+        StorageSystemFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(
+                storage_system_host_types=HOST_TYPES,
+                storage_systems=[{"name": "Storage System Name"}])
+        )
+
+    def test_should_get_reachable_ports(self):
+        self.mock_ov_client.api_version = 500
+        self.storage_systems.get_reachable_ports.return_value = [{'port': 'port1'}]
+        self.storage_systems.get_by_hostname.return_value = {"name": "Storage System Name", "uri": "rest/123"}
+        self.mock_ansible_module.params = PARAMS_GET_REACHABLE_PORTS
+
+        StorageSystemFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(
+                storage_system_reachable_ports=[{'port': 'port1'}],
+                storage_systems={"name": "Storage System Name", "uri": "rest/123"})
+        )
+
+    def test_should_get_templates(self):
+        self.mock_ov_client.api_version = 500
+        self.storage_systems.get_templates.return_value = [{'template': 'temp'}]
+        self.storage_systems.get_by_hostname.return_value = {"name": "Storage System Name", "uri": "rest/123"}
+        self.mock_ansible_module.params = PARAMS_GET_TEMPLATES
+
+        StorageSystemFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(
+                storage_system_templates=[{'template': 'temp'}],
+                storage_systems={"name": "Storage System Name", "uri": "rest/123"})
+        )
+
+    def test_should_get_storage_pools_system_by_name(self):
+        self.storage_systems.get_by_name.return_value = {"name": "Storage System Name", "uri": "uri"}
+        self.storage_systems.get_storage_pools.return_value = {"name": "Storage Pool"}
+        self.mock_ansible_module.params = PARAMS_GET_POOL_BY_NAME
+
+        StorageSystemFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(
+                storage_system_pools=({"name": "Storage Pool"}),
+                storage_systems={"name": "Storage System Name", "uri": "uri"}
+            )
+        )
+
+    def test_should_get_storage_system_pools_by_ip_hostname(self):
+        self.storage_systems.get_by_ip_hostname.return_value = {"ip_hostname": "10.0.0.0", "uri": "uri"}
+        self.storage_systems.get_storage_pools.return_value = {"name": "Storage Pool"}
+        self.mock_ansible_module.params = PARAMS_GET_POOL_BY_IP_HOSTNAME
+
+        StorageSystemFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(
+                storage_system_pools=({"name": "Storage Pool"}),
+                storage_systems={"ip_hostname": "10.0.0.0", "uri": "uri"}
+            )
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
Added new oneview_storage_system_facts module for retrieving [HPE OneView Storage Systems](http://h17007.www1.hpe.com/docs/enterprise/servers/oneview3.0/cic-api/en/api-docs/current/index.html#rest/storage-systems) resource and unit tests.

Related issue for more information: [HPE OneView support](https://github.com/ansible/ansible/issues/28354)

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`oneview_storage_system_facts`

##### ANSIBLE VERSION
```
ansible --version
ansible 2.5.0 (hpe-oneview/storage-system-facts da23d6c90b) last updated 2017/11/01 13:23:24 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /oneview-ansible/ansible/lib/ansible
  executable location = /oneview-ansible/ansible/bin/ansible
  python version = 2.7.14 (default, Oct 10 2017, 02:49:49) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
Note: to run the example you need an Oneview Appliance with some Storage System added.
Example of usage:
```yaml
- name: Gather facts about all Storage Systems
  oneview_storage_system_facts:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
  no_log: true
  delegate_to: localhost

- debug: var=storage_systems

- name: Gather paginated, filtered and sorted facts about Storage Systems
  oneview_storage_system_facts:
    params:
      start: 0
      count: 3
      sort: 'name:descending'
      filter: managedDomain=TestDomain
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
  no_log: true

- debug: var=storage_systems

- name: Gather facts about a Storage System by IP
  oneview_storage_system_facts:
    storage_hostname: "172.18.11.12"
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
  no_log: true
  delegate_to: localhost

- debug: var=storage_systems

- name: Gather facts about a Storage System by hostname
  oneview_storage_system_facts:
    storage_hostname: "172.18.11.12"
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
  no_log: true
  delegate_to: localhost

- debug: var=storage_systems


- name: Gather facts about a Storage System by name
  oneview_storage_system_facts:
    name: "ThreePAR7200-4555"
    storage_hostname: "172.18.11.12"
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
  no_log: true
  delegate_to: localhost

- debug: var=storage_systems

- name: Gather facts about a Storage System and all options
  oneview_storage_system_facts:
    name: "ThreePAR7200-4555"
    options:
        - hostTypes
        - storagePools
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
  no_log: true
  delegate_to: localhost

- debug: var=storage_systems
- debug: var=storage_system_host_types
- debug: var=storage_system_pools

- name: Gather queried facts about Storage System reachable ports
  oneview_storage_system_facts:
    storage_hostname: "172.18.11.12"
    options:
        - reachablePorts
    params:
      networks:
        - /rest/fc-networks/01FC123456
        - /rest/fc-networks/02FC123456
      sort: 'name:descending'
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
  no_log: true

- debug: var=storage_system_reachable_ports

- name: Gather facts about Storage System storage templates
  oneview_storage_system_facts:
    storage_hostname: "172.18.11.12"
    options:
      - templates
    params:
      sort: 'name:descending'
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
  no_log: true

- debug: var=storage_system_templates
```
