### PR TITLE
VolumeFactsModule for HPE OneView

### DIFF
--- a/lib/ansible/modules/remote_management/oneview/oneview_volume_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_volume_facts.py
@@ -1,0 +1,194 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2016-2017, Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: oneview_volume_facts
+short_description: Retrieve facts about the OneView Volumes
+description:
+    - Retrieve facts about the Volumes from OneView.
+version_added: "2.5"
+requirements:
+    - "hpOneView >= 4.0.0"
+author:
+    - Priyanka Sood (@soodpr)
+    - Madhav Bharadwaj (@madhav-bharadwaj)
+    - Ricardo Galeno (@ricardogpsf)
+    - Alex Monteiro (@aalexmonteiro)
+options:
+    name:
+      description:
+        - Volume name.
+    options:
+      description:
+        - "List with options to gather additional facts about Volume and related resources.
+          Options allowed: C(attachableVolumes), C(extraManagedVolumePaths), and C(snapshots). For the option
+          C(snapshots), you may provide a name."
+extends_documentation_fragment:
+    - oneview
+    - oneview.factsparams
+'''
+
+EXAMPLES = '''
+- name: Gather facts about all Volumes
+  oneview_volume_facts:
+    hostname: 10.101.42.57
+    username: administrator
+    password: serveradmin
+    api_version: 500
+  no_log: true
+
+- debug: var=storage_volumes
+
+- name: Gather paginated, filtered and sorted facts about Volumes
+  oneview_volume_facts:
+    params:
+      start: 0
+      count: 2
+      sort: 'name:descending'
+      filter: "provisioningType='Thin'"
+    hostname: 10.101.42.57
+    username: administrator
+    password: serveradmin
+    api_version: 500
+  no_log: true
+
+- debug: var=storage_volumes
+
+- name: "Gather facts about all Volumes, the attachable volumes managed by the appliance and the extra managed
+         storage volume paths"
+  oneview_volume_facts:
+    options:
+      - attachableVolumes        # optional
+      - extraManagedVolumePaths  # optional
+    hostname: 10.101.42.57
+    username: administrator
+    password: serveradmin
+    api_version: 500
+  no_log: true
+
+- debug: var=storage_volumes
+- debug: var=attachable_volumes
+- debug: var=extra_managed_volume_paths
+
+
+- name: Gather facts about a Volume by name with a list of all snapshots taken
+  oneview_volume_facts:
+    name: "{{ volume_name }}"
+    options:
+      - snapshots  # optional
+    hostname: 10.101.42.57
+    username: administrator
+    password: serveradmin
+    api_version: 500
+  no_log: true
+
+- debug: var=storage_volumes
+- debug: var=snapshots
+
+
+- name: "Gather facts about a Volume with one specific snapshot taken"
+  oneview_volume_facts:
+    name: "{{ volume_name }}"
+    options:
+      - snapshots:  # optional
+          name: "{{ snapshot_name }}"
+    hostname: 10.101.42.57
+    username: administrator
+    password: serveradmin
+    api_version: 500
+  no_log: true
+
+- debug: var=storage_volumes
+- debug: var=snapshots
+'''
+
+RETURN = '''
+storage_volumes:
+    description: Has all the OneView facts about the Volumes.
+    returned: Always, but can be null.
+    type: dict
+
+attachable_volumes:
+    description: Has all the facts about the attachable volumes managed by the appliance.
+    returned: When requested, but can be null.
+    type: dict
+
+extra_managed_volume_paths:
+    description: Has all the facts about the extra managed storage volume paths from the appliance.
+    returned: When requested, but can be null.
+    type: dict
+'''
+
+from ansible.module_utils.oneview import OneViewModuleBase
+
+
+class VolumeFactsModule(OneViewModuleBase):
+    def __init__(self):
+        argument_spec = dict(
+            name=dict(required=False, type='str'),
+            options=dict(required=False, type='list'),
+            params=dict(required=False, type='dict'),
+        )
+
+        super(VolumeFactsModule, self).__init__(additional_arg_spec=argument_spec)
+        self.resource_client = self.oneview_client.volumes
+
+    def execute_module(self):
+        ansible_facts = {}
+        networks = self.facts_params.pop('networks', None)
+        if self.module.params.get('name'):
+            ansible_facts['storage_volumes'] = self.resource_client.get_by('name', self.module.params['name'])
+            ansible_facts.update(self.__gather_facts_about_one_volume(ansible_facts['storage_volumes']))
+        else:
+            ansible_facts['storage_volumes'] = self.resource_client.get_all(**self.facts_params)
+
+        if networks:
+            self.facts_params['networks'] = networks
+
+        ansible_facts.update(self.__gather_facts_from_appliance())
+
+        return dict(changed=False, ansible_facts=ansible_facts)
+
+    def __gather_facts_from_appliance(self):
+        facts = {}
+
+        if self.options:
+            if self.options.get('extraManagedVolumePaths'):
+                extra_managed_volume_paths = self.resource_client.get_extra_managed_storage_volume_paths()
+                facts['extra_managed_volume_paths'] = extra_managed_volume_paths
+            if self.options.get('attachableVolumes'):
+                attachable_volumes = self.resource_client.get_attachable_volumes()
+                facts['attachable_volumes'] = attachable_volumes
+
+        return facts
+
+    def __gather_facts_about_one_volume(self, volumes):
+        facts = {}
+
+        if self.options.get('snapshots') and len(volumes) > 0:
+            options_snapshots = self.options['snapshots']
+            volume_uri = volumes[0]['uri']
+            if isinstance(options_snapshots, dict) and 'name' in options_snapshots:
+                facts['snapshots'] = self.resource_client.get_snapshot_by(volume_uri, 'name', options_snapshots['name'])
+            else:
+                facts['snapshots'] = self.resource_client.get_snapshots(volume_uri)
+
+        return facts
+
+
+def main():
+    VolumeFactsModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/remote_management/oneview/test_oneview_volume_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_volume_facts.py
@@ -1,0 +1,116 @@
+# Copyright: (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.compat.tests import unittest
+from ansible.modules.remote_management.oneview.oneview_volume_facts import VolumeFactsModule
+from hpe_test_utils import FactsParamsTestCase
+
+PARAMS_GET_ALL = dict(
+    config='config.json',
+    name=None
+)
+
+PARAMS_GET_ALL_WITH_OPTIONS = dict(
+    config='config.json',
+    name=None,
+    options=[
+        'attachableVolumes', 'extraManagedVolumePaths'
+    ],
+    params={
+        'networks': ['rest/fake/network']
+    }
+)
+
+PARAMS_GET_BY_NAME = dict(
+    config='config.json',
+    name="Test Volume"
+)
+
+PARAMS_GET_BY_NAME_WITH_OPTIONS = dict(
+    config='config.json',
+    name="Test Volume",
+    options=[
+        'attachableVolumes', 'extraManagedVolumePaths', 'snapshots']
+)
+
+PARAMS_GET_SNAPSHOT_BY_NAME = dict(
+    config='config.json',
+    name="Test Volume",
+    options=[{"snapshots": {"name": 'snapshot_name'}}])
+
+
+class VolumeFactsSpec(unittest.TestCase,
+                      FactsParamsTestCase):
+    def setUp(self):
+        self.configure_mocks(self, VolumeFactsModule)
+        self.resource = self.mock_ov_client.volumes
+        FactsParamsTestCase.configure_client_mock(self, self.resource)
+
+    def test_should_get_all_volumes(self):
+        self.resource.get_all.return_value = [{"name": "Test Volume"}]
+        self.mock_ansible_module.params = PARAMS_GET_ALL
+
+        VolumeFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(storage_volumes=[{"name": "Test Volume"}]))
+
+    def test_should_get_all_volumes_and_appliance_information(self):
+        self.resource.get_all.return_value = [{"name": "Test Volume"}]
+        self.resource.get_extra_managed_storage_volume_paths.return_value = ['/path1', '/path2']
+        self.resource.get_attachable_volumes.return_value = [{"name": "attachable Volume 1"}]
+
+        self.mock_ansible_module.params = PARAMS_GET_ALL_WITH_OPTIONS
+
+        VolumeFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(storage_volumes=[{"name": "Test Volume"}],
+                               attachable_volumes=[{"name": "attachable Volume 1"}],
+                               extra_managed_volume_paths=['/path1', '/path2']))
+
+    def test_should_get_volume_by_name(self):
+        self.resource.get_by.return_value = [{"name": "Test Volume", 'uri': '/uri'}]
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
+
+        VolumeFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(storage_volumes=[{"name": "Test Volume", 'uri': '/uri'}]))
+
+    def test_should_get_volume_by_name_with_snapshots_and_appliance_information(self):
+        self.resource.get_by.return_value = [{"name": "Test Volume", 'uri': '/uri'}]
+        self.resource.get_extra_managed_storage_volume_paths.return_value = ['/path1', '/path2']
+        self.resource.get_attachable_volumes.return_value = [{"name": "attachable Volume 1"}]
+        self.resource.get_snapshots.return_value = [{"filename": "snapshot_name"}]
+
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME_WITH_OPTIONS
+
+        VolumeFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(storage_volumes=[{"name": "Test Volume", 'uri': '/uri'}],
+                               attachable_volumes=[{"name": "attachable Volume 1"}],
+                               extra_managed_volume_paths=['/path1', '/path2'],
+                               snapshots=[{"filename": "snapshot_name"}]))
+
+    def test_should_get_volume_by_name_with_snapshots_by_name(self):
+        self.resource.get_by.return_value = [{"name": "Test Volume", 'uri': '/uri'}]
+        self.resource.get_snapshot_by.return_value = [{"filename": "snapshot_name"}]
+
+        self.mock_ansible_module.params = PARAMS_GET_SNAPSHOT_BY_NAME
+
+        VolumeFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(storage_volumes=[{"name": "Test Volume", 'uri': '/uri'}],
+                               snapshots=[{"filename": "snapshot_name"}]))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
Added new oneview_volume_facts module for retrieving [HPE OneView Storage Pools](http://h17007.www1.hpe.com/docs/enterprise/servers/oneview3.1/cic-api/en/api-docs/current/index.html#rest/volumes) resource and unit tests.

Related issue for more information: [HPE OneView support](https://github.com/ansible/ansible/issues/28354)

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`oneview_volume_facts`

##### ANSIBLE VERSION
```
ansible --version
ansible 2.5.0 (hpe-oneview/volume-facts f096471abf) last updated 2017/11/08 14:20:26 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /oneview-ansible/ansible/lib/ansible
  executable location = /oneview-ansible/ansible/bin/ansible
  python version = 2.7.14 (default, Oct 10 2017, 02:49:49) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
Notes:
- To run the example you need an Oneview Appliance with some Volume added and to use the version 500 of Oneview REST API.

Example of usage:
```yaml
- name: Gather facts about all Volumes
  oneview_volume_facts:
    hostname: 10.101.42.57
    username: administrator
    password: serveradmin
    api_version: 500
  no_log: true

- debug: var=storage_volumes

- name: Gather paginated, filtered and sorted facts about Volumes
  oneview_volume_facts:
    params:
      start: 0
      count: 2
      sort: 'name:descending'
      filter: "provisioningType='Thin'"
    hostname: 10.101.42.57
    username: administrator
    password: serveradmin
    api_version: 500
  no_log: true

- debug: var=storage_volumes

- name: "Gather facts about all Volumes, the attachable volumes managed by the appliance and the extra managed
         storage volume paths"
  oneview_volume_facts:
    options:
      - attachableVolumes        # optional
      - extraManagedVolumePaths  # optional
    hostname: 10.101.42.57
    username: administrator
    password: serveradmin
    api_version: 500
  no_log: true

- debug: var=storage_volumes
- debug: var=attachable_volumes
- debug: var=extra_managed_volume_paths


- name: Gather facts about a Volume by name with a list of all snapshots taken
  oneview_volume_facts:
    name: "{{ volume_name }}"
    options:
      - snapshots  # optional
    hostname: 10.101.42.57
    username: administrator
    password: serveradmin
    api_version: 500
  no_log: true

- debug: var=storage_volumes
- debug: var=snapshots


- name: "Gather facts about a Volume with one specific snapshot taken"
  oneview_volume_facts:
    name: "{{ volume_name }}"
    options:
      - snapshots:  # optional
          name: "{{ snapshot_name }}"
    hostname: 10.101.42.57
    username: administrator
    password: serveradmin
    api_version: 500
  no_log: true

- debug: var=storage_volumes
- debug: var=snapshots
```
