### PR TITLE
EnclosureGroupFactsModule for HPE OneView

### DIFF
--- a/lib/ansible/modules/remote_management/oneview/oneview_enclosure_group_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_enclosure_group_facts.py
@@ -1,0 +1,141 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2016-2017, Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: oneview_enclosure_group_facts
+short_description: Retrieve facts about one or more of the OneView Enclosure Groups
+description:
+    - Retrieve facts about one or more of the Enclosure Groups from OneView.
+version_added: "2.5"
+requirements:
+    - "hpOneView >= 4.0.0"
+author:
+    - Priyanka Sood (@soodpr)
+    - Madhav Bharadwaj (@madhav-bharadwaj)
+    - Ricardo Galeno (@ricardogpsf)
+    - Alex Monteiro (@aalexmonteiro)
+options:
+    name:
+      description:
+        - Enclosure Group name.
+    options:
+      description:
+        - "List with options to gather additional facts about Enclosure Group.
+          Options allowed:
+          C(configuration_script) Gets the configuration script for an Enclosure Group."
+
+extends_documentation_fragment:
+    - oneview
+    - oneview.factsparams
+'''
+
+EXAMPLES = '''
+- name: Gather facts about all Enclosure Groups
+  oneview_enclosure_group_facts:
+    hostname: 10.101.42.57
+    username: administrator
+    password: serveradmin
+    api_version: 500
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=enclosure_groups
+
+- name: Gather paginated, filtered and sorted facts about Enclosure Groups
+  oneview_enclosure_group_facts:
+    params:
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'status=OK'
+    hostname: 10.101.42.57
+    username: administrator
+    password: serveradmin
+    api_version: 500
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=enclosure_groups
+
+- name: Gather facts about an Enclosure Group by name with configuration script
+  oneview_enclosure_group_facts:
+    name: "Test Enclosure Group Facts"
+    options:
+      - configuration_script
+    hostname: 10.101.42.57
+    username: administrator
+    password: serveradmin
+    api_version: 500
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=enclosure_groups
+- debug: var=enclosure_group_script
+'''
+
+RETURN = '''
+enclosure_groups:
+    description: Has all the OneView facts about the Enclosure Groups.
+    returned: Always, but can be null.
+    type: dict
+
+enclosure_group_script:
+    description: The configuration script for an Enclosure Group.
+    returned: When requested, but can be null.
+    type: string
+'''
+
+from ansible.module_utils.oneview import OneViewModuleBase
+
+
+class EnclosureGroupFactsModule(OneViewModuleBase):
+    argument_spec = dict(
+        name=dict(required=False, type='str'),
+        options=dict(required=False, type='list'),
+        params=dict(required=False, type='dict')
+    )
+
+    def __init__(self):
+        super(EnclosureGroupFactsModule, self).__init__(additional_arg_spec=self.argument_spec)
+
+    def execute_module(self):
+        facts = {}
+        name = self.module.params.get('name')
+
+        if name:
+            enclosure_groups = self.oneview_client.enclosure_groups.get_by('name', name)
+
+            if enclosure_groups and "configuration_script" in self.options:
+                facts["enclosure_group_script"] = self.__get_script(enclosure_groups)
+        else:
+            enclosure_groups = self.oneview_client.enclosure_groups.get_all(**self.facts_params)
+
+        facts["enclosure_groups"] = enclosure_groups
+        return dict(changed=False, ansible_facts=facts)
+
+    def __get_script(self, enclosure_groups):
+        script = None
+
+        if enclosure_groups:
+            enclosure_group_uri = enclosure_groups[0]['uri']
+            script = self.oneview_client.enclosure_groups.get_script(id_or_uri=enclosure_group_uri)
+
+        return script
+
+
+def main():
+    EnclosureGroupFactsModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/remote_management/oneview/test_oneview_enclosure_group_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_enclosure_group_facts.py
@@ -1,0 +1,89 @@
+# Copyright: (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.compat.tests import unittest
+from ansible.modules.remote_management.oneview.oneview_enclosure_group_facts import EnclosureGroupFactsModule
+from hpe_test_utils import FactsParamsTestCase
+
+ENCLOSURE_GROUP_NAME = "Enclosure Group Name"
+ENCLOSURE_GROUP_URI = "/rest/enclosure-groups/7a298f96-fda8-480e-9747-8ad4c666f756"
+
+PARAMS_GET_ALL = dict(
+    config='config.json',
+    name=None
+)
+
+PARAMS_GET_BY_NAME = dict(
+    config='config.json',
+    name=ENCLOSURE_GROUP_NAME,
+    options=[]
+)
+
+PARAMS_GET_BY_NAME_WITH_OPTIONS = dict(
+    config='config.json',
+    name=ENCLOSURE_GROUP_NAME,
+    options=["configuration_script"]
+)
+
+ENCLOSURE_GROUPS = [{
+    "name": ENCLOSURE_GROUP_NAME,
+    "uri": ENCLOSURE_GROUP_URI
+}]
+
+
+class EnclosureGroupFactsSpec(unittest.TestCase,
+                              FactsParamsTestCase):
+    def setUp(self):
+        self.configure_mocks(self, EnclosureGroupFactsModule)
+        self.enclosure_groups = self.mock_ov_client.enclosure_groups
+        FactsParamsTestCase.configure_client_mock(self, self.enclosure_groups)
+
+    def test_should_get_all_enclosure_group(self):
+        self.enclosure_groups.get_all.return_value = ENCLOSURE_GROUPS
+
+        self.mock_ansible_module.params = PARAMS_GET_ALL
+
+        EnclosureGroupFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(enclosure_groups=ENCLOSURE_GROUPS)
+        )
+
+    def test_should_get_enclosure_group_by_name(self):
+        self.enclosure_groups.get_by.return_value = ENCLOSURE_GROUPS
+
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
+
+        EnclosureGroupFactsModule().run()
+
+        self.enclosure_groups.get_by.assert_called_once_with('name', ENCLOSURE_GROUP_NAME)
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(enclosure_groups=ENCLOSURE_GROUPS)
+        )
+
+    def test_should_get_enclosure_group_by_name_with_options(self):
+        configuration_script = "echo 'test'"
+        self.enclosure_groups.get_by.return_value = ENCLOSURE_GROUPS
+        self.enclosure_groups.get_script.return_value = configuration_script
+
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME_WITH_OPTIONS
+
+        EnclosureGroupFactsModule().run()
+
+        self.enclosure_groups.get_by.assert_called_once_with('name', ENCLOSURE_GROUP_NAME)
+        self.enclosure_groups.get_script.assert_called_once_with(id_or_uri=ENCLOSURE_GROUP_URI)
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(
+                enclosure_groups=ENCLOSURE_GROUPS,
+                enclosure_group_script=configuration_script
+            )
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
Added new oneview_enclosure_group_facts module for retrieving [HPE OneView Storage Pools](http://h17007.www1.hpe.com/docs/enterprise/servers/oneview3.1/cic-api/en/api-docs/current/index.html#rest/enclosure-groups) resource and unit tests.

Related issue for more information: [HPE OneView support](https://github.com/ansible/ansible/issues/28354)

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`oneview_enclosure_group_facts`

##### ANSIBLE VERSION
```
ansible --version
ansible 2.5.0 (hpe-oneview/enclosure-group-facts 6a770acbdb) last updated 2017/11/08 14:23:26 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /oneview-ansible/ansible/lib/ansible
  executable location = /oneview-ansible/ansible/bin/ansible
  python version = 2.7.14 (default, Oct 10 2017, 02:49:49) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
Notes:
- To run the example you need an Oneview Appliance with some Enclosure Group created and to use the version 500 of Oneview REST API.
```

Example of usage:
```yaml
- name: Gather facts about all Enclosure Groups
  oneview_enclosure_group_facts:
    hostname: 10.101.42.57
    username: administrator
    password: serveradmin
    api_version: 500
  no_log: true
  delegate_to: localhost

- debug: var=enclosure_groups

- name: Gather paginated, filtered and sorted facts about Enclosure Groups
  oneview_enclosure_group_facts:
    params:
      start: 0
      count: 3
      sort: 'name:descending'
      filter: 'status=OK'
    hostname: 10.101.42.57
    username: administrator
    password: serveradmin
    api_version: 500
  no_log: true
  delegate_to: localhost

- debug: var=enclosure_groups

- name: Gather facts about an Enclosure Group by name with configuration script
  oneview_enclosure_group_facts:
    name: "Test Enclosure Group Facts"
    options:
      - configuration_script
    hostname: 10.101.42.57
    username: administrator
    password: serveradmin
    api_version: 500
  no_log: true
  delegate_to: localhost

- debug: var=enclosure_groups
- debug: var=enclosure_group_script
```
